### PR TITLE
Miniconda is now for Python 3.6

### DIFF
--- a/doc/configure_via_anaconda.md
+++ b/doc/configure_via_anaconda.md
@@ -18,7 +18,7 @@ Using Anaconda consists of the following:
 
 ## Installation
 
-**Download** the version of `miniconda` that matches your system. Make sure you download the version for Python 3.5.
+**Download** the version of `miniconda` that matches your system. Make sure you download the version for Python 3.6.
 
 **NOTE**: There have been reports of issues creating an environment using miniconda `v4.3.13`. If it gives you issues try versions `4.3.11` or `4.2.12` from [here](https://repo.continuum.io/miniconda/).
 


### PR DESCRIPTION
The description says to install the version for Python 3.5 but miniconda now specifies python 3.6